### PR TITLE
Die when git workspace is dirty

### DIFF
--- a/lib/Mackerel/ReleaseUtils.pm
+++ b/lib/Mackerel/ReleaseUtils.pm
@@ -201,6 +201,12 @@ sub create_release_pull_request {
     if (DEBUG) {
         $Mackerel::ReleaseUtils::Log::LogLevel = Mackerel::ReleaseUtils::Log::LOG_DEBUG;
     }
+
+    # exit if workspace is dirty
+    if (`git status --porcelain`) {
+        die "git workspace is dirty. Make it clean to continue\n";
+    }
+
     chomp(my $current_branch = `git symbolic-ref --short HEAD`);
     my $branch_name;
     my $cleanup = sub {


### PR DESCRIPTION
I found that untracked file is added and pushed when I execute `make release`. It is very dangerous.

So I change `create_release_pull_request` method to check git workspace is dirty or not.  `make release` died when git workspace is dirty.


Following is a test code.

```
my $out = `cd /path/to/mackerelio/mackerel-agent; git status --porcelain`;

if ($out) {
    warn 'dirty';
}
else {
    warn 'clean';
}
```

If you want to test `make release` with changes of this pull request, please use commands below.

```
cd /path/to/mackerel-agent
export PERL5LIB=/path/to/Mackerel-ReleaseUtils/lib
make release
```