### PR TITLE
dies when ghch exits with non-0 exit status

### DIFF
--- a/lib/Mackerel/ReleaseUtils.pm
+++ b/lib/Mackerel/ReleaseUtils.pm
@@ -99,8 +99,8 @@ sub merged_prs {
     my $current_tag = shift;
 
     my $data = eval { decode_json scalar `ghch -f v$current_tag` };
-    if ($! || $@) {
-        die "parse json failed: $@";
+    if ($! || $@ || $?) {
+        die "calling ghch and/or decoding json failed: $@";
     }
     return grep {$_->{title} !~ /\[nitp?\]/i} @{ $data->{pull_requests} };
 }


### PR DESCRIPTION
output of `ghch -f` is always valid JSON, even if github API request failed for some reason.
With this p-r, in such cases `merged_prs` dies in order to stop processing.

# memo

```
[astj@gemmy01 ~]$ perl -MData::Dumper -MJSON::PP -E 'my $data = eval { JSON::PP::decode_json scalar `ls /notfound` }; printf("%s, %s, %s\n", $@, $?, $!); say Dumper $data ;'
ls: /notfound: No such file or directory
malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "(end of string)") at -e line 1.
, 256,
$VAR1 = undef;

[astj@gemmy01 ~]$ perl -MData::Dumper -MJSON::PP -E 'my $data = eval { JSON::PP::decode_json scalar `echo [3}` }; printf("%s, %s, %s\n", $@, $?, $!); say Dumper $data ;'
, or ] expected while parsing array, at character offset 3 (before "\n") at -e line 1.
, 0,
$VAR1 = undef;

[astj@gemmy01 ~]$ perl -MData::Dumper -MJSON::PP -E 'my $data = eval { JSON::PP::decode_json scalar `echo [3} && exit 1` }; printf("%s, %s, %s\n", $@, $?, $!); say Dumper $data ;'
, or ] expected while parsing array, at character offset 3 (before "\n") at -e line 1.
, 256,
$VAR1 = undef;

[astj@gemmy01 ~]$ perl -MData::Dumper -MJSON::PP -E 'my $data = eval { JSON::PP::decode_json scalar `echo [3]` }; printf("%s, %s, %s\n", $@, $?, $!); say Dumper $data ;'
, 0,
$VAR1 = [
          3
        ];

[astj@gemmy01 ~]$ perl -MData::Dumper -MJSON::PP -E 'my $data = eval { JSON::PP::decode_json scalar `echo [3] && exit 1` }; printf("%s, %s, %s\n", $@, $?, $!); say Dumper $data ;'
, 256,
$VAR1 = [
          3
        ];
```